### PR TITLE
feat(run-manager): add keygen command to generate a new Solana keypair

### DIFF
--- a/psyche-book/src/enduser/join-run.md
+++ b/psyche-book/src/enduser/join-run.md
@@ -44,7 +44,13 @@ To install the NVIDIA Container Toolkit, follow the [NVIDIA Container Toolkit in
 
 You need a Solana keypair (wallet) to participate in training. This keypair identifies your client on the blockchain.
 
-If you need to create a new keypair, you can use the Solana CLI, specifying where you want to create it
+If you need to create a new keypair, you can use the run manager itself, specifying where you want to create it
+
+```bash
+run-manager keygen --output <path/to/keypair/file.json>
+```
+
+Alternatively, use the Solana CLI, which produces the same file format
 
 ```bash
 solana-keygen new --outfile <path/to/keypair/file.json>

--- a/tools/rust-tools/run-manager/src/commands/keygen.rs
+++ b/tools/rust-tools/run-manager/src/commands/keygen.rs
@@ -1,0 +1,44 @@
+use anchor_client::solana_sdk::signature::{EncodableKey, Keypair};
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Args)]
+#[command()]
+pub struct CommandKeygen {
+    /// Path where the new keypair JSON file will be written
+    #[clap(short, long)]
+    pub output: PathBuf,
+
+    /// Overwrite the output file if it already exists
+    #[clap(short, long, default_value_t = false)]
+    pub force: bool,
+}
+
+impl CommandKeygen {
+    /// Generates a new Solana keypair and writes it to the requested path as
+    /// a JSON array of 64 bytes, the same format the solana-cli produces
+    /// (`solana-keygen new --outfile`), so the file can be dropped into
+    /// `WALLET_PATH` / `WALLET_PRIVATE_KEY_PATH` or used with any other
+    /// solana tooling.
+    pub fn execute(self) -> Result<()> {
+        let Self { output, force } = self;
+
+        if output.exists() && !force {
+            bail!(
+                "output file {} already exists, use --force to overwrite",
+                output.display()
+            );
+        }
+
+        let keypair = Keypair::new();
+        keypair
+            .write_to_file(&output)
+            .with_context(|| format!("Failed to write keypair to {}", output.display()))?;
+
+        println!("Wrote new keypair to {}", output.display());
+        println!("Public key: {}", keypair.pubkey());
+
+        Ok(())
+    }
+}

--- a/tools/rust-tools/run-manager/src/commands/mod.rs
+++ b/tools/rust-tools/run-manager/src/commands/mod.rs
@@ -2,6 +2,7 @@ mod command;
 
 pub mod authorization;
 pub mod can_join;
+pub mod keygen;
 pub mod run;
 pub mod treasury;
 

--- a/tools/rust-tools/run-manager/src/main.rs
+++ b/tools/rust-tools/run-manager/src/main.rs
@@ -22,6 +22,7 @@ use commands::authorization::{
     CommandJoinAuthorizationDelete, CommandJoinAuthorizationRead,
 };
 use commands::can_join::CommandCanJoin;
+use commands::keygen::CommandKeygen;
 use commands::run::{
     CommandCheckpoint, CommandCloseRun, CommandCreateRun, CommandDownloadResults,
     CommandJsonDumpRun, CommandJsonDumpUser, CommandSetFutureEpochRates, CommandSetPaused,
@@ -240,6 +241,12 @@ enum Commands {
         params: CommandCanJoin,
     },
 
+    // Generate a new keypair
+    Keygen {
+        #[clap(flatten)]
+        params: CommandKeygen,
+    },
+
     /// List joinable runs on the coordinator program
     ListRuns {
         /// Path to .env file with RPC and wallet configuration
@@ -418,6 +425,7 @@ async fn async_main() -> Result<()> {
         Commands::CanJoin { cluster, params } => {
             params.execute(create_backend_readonly(cluster)?).await
         }
+        Commands::Keygen { params } => params.execute(),
         Commands::ListRuns {
             env_file,
             cluster,


### PR DESCRIPTION
## Summary

Adds a `run-manager keygen` command that generates a new Solana keypair and writes it to disk in the same JSON format the solana-cli produces, so creating a wallet no longer requires installing the solana binaries.

Closes #500.

## Usage

```bash
run-manager keygen --output ~/.config/solana/psyche-node.json
# Wrote new keypair to /home/user/.config/solana/psyche-node.json
# Public key: 7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU
```

- The output file is the standard 64-byte JSON array (identical to `solana-keygen new --outfile`), directly usable as `WALLET_PATH` / `WALLET_PRIVATE_KEY_PATH` in the `.env` file.
- Refuses to overwrite an existing file unless `--force` is passed.
- `write_to_file` creates parent directories and restricts permissions to `0600` on unix (both provided by `solana_sdk`'s `EncodableKey` implementation).
- Purely offline — no cluster connection, so it's usable without an `.env` or RPC endpoint.

## Notes for reviewers

- Follows the existing command conventions: `#[derive(Debug, Clone, Args)]` + `#[command()]`, registered in `Commands` in `main.rs`; dispatched without a `SolanaBackend` since it needs no network access.
- `Keypair::new()` (OS entropy) + `EncodableKey::write_to_file` are the same primitives `solana-keygen` uses, via the already-required `anchor-client` re-export of `solana_sdk`.
- The book's [Joining a run](https://psychebook.psyche.network/enduser/join-run.html) page is updated in a second commit to show `run-manager keygen` as the primary path (solana-cli kept as an alternative).
- Local `cargo check` is blocked on Windows by the vendored `openssl-sys` build (needs perl; CI builds run on Ubuntu with libssl-dev), so compile verification is left to CI — the touched APIs (`Keypair::new`, `write_to_file`, `pubkey`) are verified against solana-sdk 2.1.4 sources.
