### PR TITLE
docs(book): point source links at the renamed nousnet repository

### DIFF
--- a/psyche-book/src/development/contributing.md
+++ b/psyche-book/src/development/contributing.md
@@ -2,9 +2,9 @@
 
 ### **Found a bug?**
 
-- **Make sure we're not already aware of it** by checking [GitHub Issues](https://github.com/PsycheFoundation/psyche/issues).
+- **Make sure we're not already aware of it** by checking [GitHub Issues](https://github.com/PsycheFoundation/nousnet/issues).
 
-- If it seems your bug is new, [open an issue](https://github.com/PsycheFoundation/psyche/issues). Describe the expected & actual behaviour in as much detail as possible, ensuring to include system information (CUDA? CPU?) and any relevant command-line params (data parallelism? tensor parallelism? compression ratio?).
+- If it seems your bug is new, [open an issue](https://github.com/PsycheFoundation/nousnet/issues). Describe the expected & actual behaviour in as much detail as possible, ensuring to include system information (CUDA? CPU?) and any relevant command-line params (data parallelism? tensor parallelism? compression ratio?).
 
 ### **Fixed a bug?**
 

--- a/psyche-book/src/enduser/authentication.md
+++ b/psyche-book/src/enduser/authentication.md
@@ -76,4 +76,4 @@ run-manager join-authorization-delete \
 
 To see how the authorization creation for a real run fits in the configuration see the [Authorization section](./create-run.md#Setting-up-Join-Authorizations) in the create run guide.
 
-The source code for the `authorizer` smart contract used by the Psyche's coordinator can be found here with its readme: <https://github.com/PsycheFoundation/psyche/tree/main/architectures/decentralized/solana-authorizer>
+The source code for the `authorizer` smart contract used by the Psyche's coordinator can be found here with its readme: <https://github.com/PsycheFoundation/nousnet/tree/main/architectures/decentralized/solana-authorizer>

--- a/psyche-book/src/enduser/client-faq.md
+++ b/psyche-book/src/enduser/client-faq.md
@@ -17,4 +17,4 @@
 - Do I need a Solana wallet to train? Does it need to have funds?
   - Yes, even if you want to join a run that does not track rewards you will need a Solana wallet with funds to pay for the transactions to the coordinator.
 - Are the client and coordinator open-source? Can I report bugs?
-  - Yes, you may check [Psyche's github repo](https://github.com/PsycheFoundation/psyche)
+  - Yes, you may check [Psyche's github repo](https://github.com/PsycheFoundation/nousnet)

--- a/psyche-book/src/enduser/run-config.md
+++ b/psyche-book/src/enduser/run-config.md
@@ -5,7 +5,7 @@ It's a `.toml` file with information about the model shape, size, checkpoints, o
 
 There's two top-level values in a run configuration: a `config`, and a `model`.
 
-While some examples are described below, you can find the full range of options [for the coordinator here](https://github.com/PsycheFoundation/psyche/blob/main/shared/coordinator/src/coordinator.rs) and [for the model here](https://github.com/PsycheFoundation/psyche/blob/main/shared/coordinator/src/model.rs)
+While some examples are described below, you can find the full range of options [for the coordinator here](https://github.com/PsycheFoundation/nousnet/blob/main/shared/coordinator/src/coordinator.rs) and [for the model here](https://github.com/PsycheFoundation/nousnet/blob/main/shared/coordinator/src/model.rs)
 
 ## Config
 

--- a/psyche-book/src/explain/rewards.md
+++ b/psyche-book/src/explain/rewards.md
@@ -10,10 +10,10 @@ A Training run can be created through a `Treasurer` escrow smart contract. In th
 
 In this case, an arbitrary token can be distributed through the `Treasurer`'s Token holding. Every time a client earns a point on the run's coordinator, the treasurer will allow claiming a fixed amount of reward token for each earned coordinator point.
 
-The source code for the treasurer smart contract can be found here: <https://github.com/PsycheFoundation/psyche/tree/main/architectures/decentralized/solana-treasurer>.
+The source code for the treasurer smart contract can be found here: <https://github.com/PsycheFoundation/nousnet/tree/main/architectures/decentralized/solana-treasurer>.
 
 ## Mining Pool, Pooling funds
 
-Participating in a run can be expensive — a powerful GPU may be required to train a particular model. Users can pool resources together through a Mining Pool smart contract. The source code used can be found here: <https://github.com/PsycheFoundation/psyche/tree/main/architectures/decentralized/solana-mining-pool>.
+Participating in a run can be expensive — a powerful GPU may be required to train a particular model. Users can pool resources together through a Mining Pool smart contract. The source code used can be found here: <https://github.com/PsycheFoundation/nousnet/tree/main/architectures/decentralized/solana-mining-pool>.
 
 Each user contributing to a Mining Pool will delegate their funds so those can be used by the Mining Pool authority and owner to purchase compute power. The Mining Pool authority can then re-distribute equitably through the Mining Pool any token that may have been received as a result of the training.


### PR DESCRIPTION
Updates the 8 remaining book links that still reference the repository's pre-rename name (\PsycheFoundation/psyche\) to the canonical \PsycheFoundation/nousnet\ URLs.

The old links currently work via GitHub redirects, but:
- they break if the redirect is ever removed,
- linkcheck tooling reports them as redirects rather than clean 200s,
- and new contributors following them land on URLs that don't match the repo they cloned.

Files touched (link-only change, no prose modified):
- \development/contributing.md\ (issue links)
- \enduser/authentication.md\ (authorizer contract source)
- \enduser/client-faq.md\ (repo link)
- \enduser/run-config.md\ (coordinator.rs / model.rs source links)
- \explain/rewards.md\ (treasurer + mining-pool contract sources)

All five URLs verified live (HTTP 200) against \main\.