### PR TITLE
docs(book): fix wrong WALLET_PATH env var and small typos

### DIFF
--- a/psyche-book/src/development/setup.md
+++ b/psyche-book/src/development/setup.md
@@ -15,8 +15,7 @@ To install Nix, simply run the `./setup-nix.sh` script. This will install Nix an
 
 ##### Binary cache
 
-If you already have Nix installed, or are installing it manually,
-To speed up your builds & your local dev shell, we recommend enabling the binary cache from `garnix`, our CI provider.
+If you already have Nix installed, or are installing it manually, you can speed up your builds & your local dev shell by enabling the binary cache from `garnix`, our CI provider.
 
 In order to use the cache that garnix provides, change your `nix.conf`, adding `https://cache.garnix.io` to substituters, and `cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=` to `trusted-public-keys`.
 

--- a/psyche-book/src/enduser/join-run.md
+++ b/psyche-book/src/enduser/join-run.md
@@ -58,7 +58,7 @@ Before running it, you should create an environment file with some needed variab
 The `.env` file should have at least this defined:
 
 ```bash
-WALLET_PATH=/path/to/your/keypair.json
+WALLET_PRIVATE_KEY_PATH=/path/to/your/keypair.json
 
 # Required: Solana RPC Endpoints
 RPC=https://your-primary-rpc-provider.com

--- a/psyche-book/src/explain/data-provider.md
+++ b/psyche-book/src/explain/data-provider.md
@@ -53,7 +53,7 @@ We also support loading data from GCP as a subsection of the HTTP data provider.
 The required configuration depends on the data provider implementation being used:
 
 1. **TCP Server**:
-   - If the data provider is configured as a TCP server, and an additional file named `data.toml` is required.
+   - If the data provider is configured as a TCP server, an additional file named `data.toml` is required.
    - This file contains the configuration required for the TCP server, including:
      - Data location
      - Token size

--- a/psyche-book/src/intro.md
+++ b/psyche-book/src/intro.md
@@ -25,4 +25,4 @@ Psyche is built to maintain training integrity without requiring participants to
 
 ## Client Quickstart
 
-If you are a client wanting to join an exiting training round you can refer to the [join a run documentation](./enduser/join-run.md)
+If you are a client wanting to join an existing training round you can refer to the [join a run documentation](./enduser/join-run.md)


### PR DESCRIPTION
## Summary

- **\WALLET_PATH\ → \WALLET_PRIVATE_KEY_PATH\** in the [Joining a run](https://psychebook.psyche.network/enduser/join-run.html) quickstart \.env\ example. \un-manager\ only reads \RAW_WALLET_PRIVATE_KEY\ or \WALLET_PRIVATE_KEY_PATH\ (see \load_wallet_key\ in \	ools/rust-tools/run-manager/src/lib.rs\), so the documented \WALLET_PATH\ variable was silently unused and following the guide verbatim fails with \No wallet private key!\. The quickstart-compute-provider page already used the correct variable; this brings the two pages in sync.
- Fixes \'exiting training round'\ → \'existing training round'\ in the intro.
- Repairs a broken sentence in the nix binary-cache section of \development/setup.md\.
- Drops a stray \'and'\ in the TCP data-provider notes (\explain/data-provider.md\).

Link-only + typo fixes; no prose restructuring.