### PR TITLE
feat(website): add SHOW_ALL_RUNS debug flag and ALLOWLISTED_RUN_IDS override

### DIFF
--- a/website/backend/src/dataStores/flatFileCoordinator.ts
+++ b/website/backend/src/dataStores/flatFileCoordinator.ts
@@ -28,34 +28,43 @@ import { CURRENT_VERSION } from 'shared/formats/type.js'
 import { existsSync, renameSync } from 'fs'
 
 // any run ID outside this list will not be returned to the frontend in the summary list,
-const ALLOWLISTED_RUN_IDS =
-	process.env.NODE_ENV === 'development'
-		? null
-		: [
-				'consilience-40b-1',
-				'hermes-3-8b',
-				'hermes-3-8b-2',
-				'hermes-4-8b',
-				'hermes-4-8b-2',
-				'dm-fwedu-baseline',
-				'dm-fwedu-baseline-2',
-				'dm-dclm-baseline',
-				'dm-fwedu-dclm',
-				'dm-fwedu-dclm-fpdf',
-				'dm-fwedu-dclm-fw2hq',
-				'dm-fwedu-dclm-stack',
-				'dm-fwedu-dclm-stack-nmath',
-				'dm-fwedu-dclm-wiki-pes',
-				'dm-consilience-rc1',
-				'dm-consilience-rc2',
-				'dm-consilience-rc3',
-				'dm-consilience-rc4',
-				'hermes-4-36b',
-				'hermes-4.1-36b',
-				'hermes-4.3-36b',
-				'hermes-4.3-36b-2',
-				'moe-10b-a1b-8k-wsd-lr3e4-1t',
-			]
+// unless SHOW_ALL_RUNS is set (debug), in which case the allowlist is skipped entirely.
+// The list itself can be replaced at runtime with ALLOWLISTED_RUN_IDS (comma-separated).
+const ALLOWLISTED_RUN_IDS = (() => {
+	if (process.env.NODE_ENV === 'development' || process.env.SHOW_ALL_RUNS) {
+		return null
+	}
+	if (process.env.ALLOWLISTED_RUN_IDS) {
+		return process.env.ALLOWLISTED_RUN_IDS.split(',')
+			.map((id) => id.trim())
+			.filter(Boolean)
+	}
+	return [
+		'consilience-40b-1',
+		'hermes-3-8b',
+		'hermes-3-8b-2',
+		'hermes-4-8b',
+		'hermes-4-8b-2',
+		'dm-fwedu-baseline',
+		'dm-fwedu-baseline-2',
+		'dm-dclm-baseline',
+		'dm-fwedu-dclm',
+		'dm-fwedu-dclm-fpdf',
+		'dm-fwedu-dclm-fw2hq',
+		'dm-fwedu-dclm-stack',
+		'dm-fwedu-dclm-stack-nmath',
+		'dm-fwedu-dclm-wiki-pes',
+		'dm-consilience-rc1',
+		'dm-consilience-rc2',
+		'dm-consilience-rc3',
+		'dm-consilience-rc4',
+		'hermes-4-36b',
+		'hermes-4.1-36b',
+		'hermes-4.3-36b',
+		'hermes-4.3-36b-2',
+		'moe-10b-a1b-8k-wsd-lr3e4-1t',
+	]
+})()
 
 type WitnessV2 = Omit<
 	WitnessMetadata,


### PR DESCRIPTION
## Summary

The website backend gates which runs appear on psyche.network behind a hardcoded allowlist (\ALLOWLISTED_RUN_IDS\ in \latFileCoordinator.ts\), bypassed only when \NODE_ENV=development\. Per #596 there is no way to see all runs outside local development.

This adds two backend environment knobs, no API changes:

- **\SHOW_ALL_RUNS\** — any truthy value skips the allowlist entirely. Intended for debugging and incident response (e.g. verifying a run exists on-chain but is missing from the site).
- **\ALLOWLISTED_RUN_IDS\** — comma-separated list overriding the hardcoded set, so deployments can change the visible runs without a code change. Empty entries are ignored.

Default behavior is unchanged: production still uses the same hardcoded list, development still bypasses it.

Closes #596 (backend portion — the issue title mentions the frontend, but the filtering happens here; a follow-up frontend toggle would just consume the existing endpoints once the backend exposes the data).

## Notes

- The allowlist is now built once in an IIFE, keeping the original list verbatim as the fallback.
- Verified with eslint on the changed file: zero errors on the changed lines (the file has pre-existing type-checked-lint errors from generated IDL types that also exist on \main\).