### PR TITLE
docs(book): fix missing H1 and misleading page titles

### DIFF
--- a/psyche-book/src/development/contributing.md
+++ b/psyche-book/src/development/contributing.md
@@ -1,12 +1,12 @@
-## Contributing to Psyche
+# Contributing to Psyche
 
-### **Found a bug?**
+## **Found a bug?**
 
 - **Make sure we're not already aware of it** by checking [GitHub Issues](https://github.com/PsycheFoundation/psyche/issues).
 
 - If it seems your bug is new, [open an issue](https://github.com/PsycheFoundation/psyche/issues). Describe the expected & actual behaviour in as much detail as possible, ensuring to include system information (CUDA? CPU?) and any relevant command-line params (data parallelism? tensor parallelism? compression ratio?).
 
-### **Fixed a bug?**
+## **Fixed a bug?**
 
 - Submit a GitHub PR with your bugfix.
 
@@ -14,16 +14,16 @@
 
 - Before submitting, check out our [guidelines](#pr-guidelines) to keep things consistent.
 
-### **Want to add a cool feature or change something?**
+## **Want to add a cool feature or change something?**
 
 - First, share your idea on the [Psyche forum](https://forum.psyche.network/) and get some feedback.
 - Feel free to start developing whenever you want, but we generally won't accept a PR unless there's been some discussion and feedback about whether your feature fits Psyche's goals.
 
-### **Have questions about how things work?**
+## **Have questions about how things work?**
 
 - Post your questions on the [Psyche forum](https://forum.psyche.network/) - that's the best place to get answers!
 
-### **Want to improve our docs?**
+## **Want to improve our docs?**
 
 - We'd love that. Feel free to open PRs!
 
@@ -34,18 +34,18 @@ Thank you for your contributions to Psyche :heart:
 We prefer PRs to be made and merged using rebase, not merge commits.
 It's not a deal-breaker, but rebase makes us happy \<3
 
-### Clean Linear History
+## Clean Linear History
 
 Rebasing creates a linear commit history without merges going back and forth, making it much easier to identify the place a change was made.
 Fix-ups in merge commits that introduce bugs are no longer associated with the original code, whereas with with rebase you'd find the bug as part of its original commit.
 
 Merge commits add extra noise to the history without adding meaningful content about what changed.
 
-### Better Bisect Experience
+## Better Bisect Experience
 
 A linear history makes `git bisect` more effective for finding bugs, as each commit represents a coherent, working state of the codebase.
 
-### Preserving Meaningful Commits
+## Preserving Meaningful Commits
 
 While we advocate for rebase, **we do not advocate for squashing all commits**. Each commit should:
 
@@ -58,7 +58,7 @@ While we advocate for rebase, **we do not advocate for squashing all commits**. 
    - Documentation updates
 4. **Build & pass all checks** if checked out individually.
 
-### What to Avoid
+## What to Avoid
 
 - **Don't squash meaningful commits together** - this buries important changes in large diffs and loses the step-by-step narrative
 - **Don't use merge commits** within feature branches

--- a/psyche-book/src/enduser/index.md
+++ b/psyche-book/src/enduser/index.md
@@ -1,4 +1,4 @@
-# End-user configuration
+# End-user usage
 
 ## Joining a run
 

--- a/psyche-book/src/enduser/quickstart-compute-provider.md
+++ b/psyche-book/src/enduser/quickstart-compute-provider.md
@@ -1,4 +1,4 @@
-# Quickstart: Providing Compute to NousNet
+# Quickstart: Providing Compute to Psyche
 
 This guide walks you through the complete process of setting up your machine to provide compute to a NousNet training run. It assumes you have been provided the `run-manager` binary by the run administrator.
 


### PR DESCRIPTION
## Summary

Three page-title defects found by cross-checking every \SUMMARY.md\ entry against each page's first heading:

- **\development/contributing.md\ had no H1 at all** — the page title existed only as an H2, so the rendered page had no top-level heading and mdbook's chapter title came solely from the sidebar. Promoted to H1 and demoted the sections one level to keep the hierarchy consistent.
- **\enduser/index.md\** — H1 said \End-user configuration\ but the chapter is \End-user usage\ (and the page is an index, not a config reference).
- **\enduser/quickstart-compute-provider.md\** — H1 said \Providing Compute to NousNet\, a brand name the rest of the book doesn't use (everything else says Psyche).

Left untouched: the many sidebar-label-vs-H1 differences that are intentional short labels (\Rewards\ vs \Training Rewards\, etc.).

No links, no prose changes beyond the three titles.