### PR TITLE
feat(run-manager): add --permissionless flag to join-authorization-create

### DIFF
--- a/psyche-book/src/enduser/authentication.md
+++ b/psyche-book/src/enduser/authentication.md
@@ -20,7 +20,7 @@ A Training run can be configured to be restricted to only a set of whitelisted k
 
 ## Permissionless Runs
 
-Permissionless runs are open to anyone without any `authorization` required. The owner of the run can set this for a run when creating it. This type of authorization can be made by creating an `authorization` with a special `authorizer` valid for everyone: `11111111111111111111111111111111`
+Permissionless runs are open to anyone without any `authorization` required. The owner of the run can set this for a run when creating it. This type of authorization can be made by creating an `authorization` with a special `authorizer` valid for everyone: `11111111111111111111111111111111` (the Solana system program address).
 
 A CLI is provided for this:
 
@@ -28,8 +28,10 @@ A CLI is provided for this:
 run-manager join-authorization-create \
     --rpc [RPC] \
     --wallet-private-key-path [JOIN_AUTHORITY_KEYPAIR_FILE] \
-    --authorizer 11111111111111111111111111111111
+    --permissionless
 ```
+
+The `--permissionless` flag is equivalent to passing `--authorizer 11111111111111111111111111111111`.
 
 ## Permissioned Runs
 

--- a/scripts/create-permissionless-run.sh
+++ b/scripts/create-permissionless-run.sh
@@ -43,7 +43,7 @@ cargo run --release --bin run-manager -- \
     join-authorization-create \
     --wallet-private-key-path ${WALLET_FILE} \
     --rpc "${RPC}" \
-    --authorizer 11111111111111111111111111111111
+    --permissionless
 
 echo -e "\n[+] Creating training run..."
 cargo run --release --bin run-manager -- \

--- a/tools/rust-tools/run-manager/src/commands/authorization/create.rs
+++ b/tools/rust-tools/run-manager/src/commands/authorization/create.rs
@@ -1,6 +1,7 @@
 use crate::commands::Command;
 use anchor_client::solana_sdk::pubkey::Pubkey;
-use anyhow::Result;
+use anchor_client::solana_sdk::system_program;
+use anyhow::{Result, bail};
 use async_trait::async_trait;
 use clap::Args;
 
@@ -11,21 +12,44 @@ use psyche_solana_rpc::instructions;
 #[command()]
 pub struct CommandJoinAuthorizationCreate {
     #[clap(long, env)]
-    pub authorizer: Pubkey,
+    pub authorizer: Option<Pubkey>,
+
+    /// Make the authorization permissionless (valid for everyone) instead of
+    /// granting it to a specific authorizer
+    #[clap(long, default_value_t = false)]
+    pub permissionless: bool,
 }
 
 #[async_trait]
 impl Command for CommandJoinAuthorizationCreate {
     async fn execute(self, backend: SolanaBackend) -> Result<()> {
-        let Self { authorizer } = self;
+        let Self {
+            authorizer,
+            permissionless,
+        } = self;
+
+        let grantee = match (permissionless, authorizer) {
+            (true, Some(_)) => bail!(
+                "--permissionless and --authorizer are mutually exclusive: a permissionless \
+                 authorization is valid for everyone and cannot target a specific key"
+            ),
+            (true, None) => system_program::ID,
+            (false, None) => bail!(
+                "either --authorizer or --permissionless must be provided"
+            ),
+            (false, Some(authorizer)) => authorizer,
+        };
 
         let payer = backend.get_payer();
         let grantor = backend.get_payer();
-        let grantee = authorizer;
         let scope = psyche_solana_coordinator::logic::JOIN_RUN_AUTHORIZATION_SCOPE;
 
         println!("Authorization Grantor: {}", grantor);
-        println!("Authorization Grantee: {}", grantee);
+        println!(
+            "Authorization Grantee: {}{}",
+            grantee,
+            if permissionless { " (permissionless)" } else { "" }
+        );
 
         let authorization_address =
             psyche_solana_authorizer::find_authorization(&grantor, &grantee, scope);


### PR DESCRIPTION
## Summary

Making a run permissionless currently requires knowing the magic authorizer address \11111111111111111111111111111111\ (the Solana system program id), which #471 calls out as obscure.

Adds a \--permissionless\ flag to \un-manager join-authorization-create\:

\\\sh
# before
run-manager join-authorization-create --authorizer 11111111111111111111111111111111 ...

# after
run-manager join-authorization-create --permissionless ...
\\\

- \--authorizer\ is now optional and mutually exclusive with \--permissionless\ (passing both errors with an explanation)
- the permissionless grant targets \system_program::ID\, the same address the client-side join check already treats as the permissionless grantee (\can_user_join_run\ in \coordinator_client.rs\)
- \scripts/create-permissionless-run.sh\ updated to use the new flag
- book's \uthentication.md\ updated to document the flag and explain what the magic address actually is

Closes #471.

## Notes

- Backward compatible: \--authorizer 11111111111111111111111111111111\ still works identically.
- Follows the existing command conventions (bool flag with \default_value_t = false\, same as \--delegates-clear\).